### PR TITLE
fix: Tester le workflow de documentation avec la branche 7-la-cicd-est-cassee

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: 📚 Deploy Documentation
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, 7-la-cicd-est-cassee]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'


### PR DESCRIPTION
## Résumé

Ajout de la branche `7-la-cicd-est-cassee` au workflow de documentation pour vérifier que la CI/CD fonctionne correctement maintenant que le répertoire `src/` a été créé.

## Contexte

Le workflow de documentation échouait précédemment avec l'erreur:
```
error: error in 'egg_base' option: 'src' does not exist or is not a directory
```

Cette erreur a été corrigée en amont par la création du répertoire `src/` et la structure de package Python.

## Changements

- Ajout de la branche `7-la-cicd-est-cassee` dans `.github/workflows/docs.yml` pour permettre le test du workflow sur cette branche

## Test plan

- [ ] Vérifier que le workflow de documentation se déclenche au push
- [ ] Vérifier que le build MkDocs réussit
- [ ] Vérifier qu'il n'y a plus d'erreurs liées au répertoire `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #7