### PR TITLE
feat(calibre): add optional Calibre library integration to backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,35 @@ LOG_PATH=./data/logs
 MONGO_LOG_PATH=./data/logs/mongodb
 
 # ============================================================================
+# Calibre Integration (Optionnel)
+# ============================================================================
+# Intégration d'une bibliothèque Calibre existante au back-office.
+# Le volume est monté en lecture seule pour éviter toute modification.
+# Aucune installation de Calibre n'est requise (lecture directe de metadata.db).
+#
+# ⚠️  IMPORTANT pour Portainer : Utiliser des chemins ABSOLUS
+# Portainer résout les chemins relatifs depuis son propre répertoire de travail,
+# pas depuis le répertoire du docker-compose.yml.
+#
+# Laisser vide ou commenter pour désactiver l'intégration Calibre.
+
+# --- NAS Synology ---
+# CALIBRE_HOST_PATH=/volume1/books/Calibre Library
+
+# --- Linux ---
+# CALIBRE_HOST_PATH=/home/user/Calibre Library
+
+# --- Mac ---
+# CALIBRE_HOST_PATH=/Users/username/Calibre Library
+
+# --- Windows (WSL2 ou Docker Desktop) ---
+# CALIBRE_HOST_PATH=/mnt/c/Users/username/Calibre Library
+
+# Tag de bibliothèque virtuelle Calibre (optionnel)
+# Permet de filtrer les livres selon un tag spécifique
+# CALIBRE_VIRTUAL_LIBRARY_TAG=guillaume
+
+# ============================================================================
 # Backup Configuration
 # ============================================================================
 # Nombre de semaines de rétention des backups (défaut: 7)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Stack Docker complète pour déployer [LMELP (Le Masque et La Plume)](https://gi
 ## ✨ Fonctionnalités
 
 - **Stack complète** : MongoDB + LMELP App + Back-Office (Frontend + Backend)
+- **Intégration Calibre** : Accès optionnel à votre bibliothèque Calibre existante depuis le back-office
 - **Backups automatisés** : Sauvegardes hebdomadaires de MongoDB avec anacron (adapté aux NAS/PC non 24/7)
 - **Rotation des logs** : Rotation automatique quotidienne des logs MongoDB
 - **Image MongoDB personnalisée** : Disponible sur ghcr.io avec backup et rotation intégrés
@@ -75,6 +76,7 @@ La documentation complète est disponible sur **[castorfou.github.io/docker-lmel
 
 - **[Installation](https://castorfou.github.io/docker-lmelp/user/installation/)** : Guide d'installation détaillé
 - **[Configuration](https://castorfou.github.io/docker-lmelp/user/configuration/)** : Variables d'environnement et personnalisation
+- **[Intégration Calibre](https://castorfou.github.io/docker-lmelp/user/calibre-setup/)** : Accès à votre bibliothèque Calibre (optionnel)
 - **[Backups & Restauration](https://castorfou.github.io/docker-lmelp/user/backup-restore/)** : Gestion des sauvegardes
 - **[Rotation des logs MongoDB](https://castorfou.github.io/docker-lmelp/user/mongodb-log-rotation/)** : Gestion automatique des logs
 - **[Déploiement Portainer](https://castorfou.github.io/docker-lmelp/user/portainer/)** : Installation via interface graphique

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,11 +99,15 @@ services:
       - "${BACKEND_PORT:-8000}:8000"
     depends_on:
       - mongo
+    volumes:
+      - ${CALIBRE_HOST_PATH:-/dev/null}:/calibre:ro
     environment:
       - MONGODB_URL=mongodb://mongo:27017/${MONGO_DATABASE:-masque_et_la_plume}
       - ENVIRONMENT=production
       - API_HOST=0.0.0.0
       - API_PORT=8000
+      # Calibre integration (optionnel)
+      - CALIBRE_VIRTUAL_LIBRARY_TAG=${CALIBRE_VIRTUAL_LIBRARY_TAG:-}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s

--- a/docs/claude/memory/251129-2150-integration-calibre.md
+++ b/docs/claude/memory/251129-2150-integration-calibre.md
@@ -1,0 +1,102 @@
+# Intégration Calibre dans docker-lmelp
+
+**Date** : 2025-11-29
+**Issue** : #27
+**Contexte** : Intégration de la fonctionnalité Calibre développée dans back-office-lmelp (issue #119)
+
+## Décision d'architecture
+
+### Approche choisie : Montage volume lecture seule
+
+L'intégration Calibre utilise un montage de volume en **lecture seule** (`:ro`) pour accéder à une bibliothèque Calibre existante depuis le back-office LMELP.
+
+**Principes de conception** :
+- **Optionnel** : Le système fonctionne normalement sans Calibre configuré
+- **Lecture seule** : Montage `:ro` pour éviter toute corruption de la bibliothèque
+- **Pas d'installation** : Pas besoin d'installer Calibre dans le conteneur (lecture directe SQLite)
+- **Portable** : Support multi-plateforme (NAS Synology, Linux, Mac, Windows)
+
+### Configuration Docker Compose
+
+```yaml
+backend:
+  volumes:
+    - ${CALIBRE_HOST_PATH:-/dev/null}:/calibre:ro
+  environment:
+    - CALIBRE_VIRTUAL_LIBRARY_TAG=${CALIBRE_VIRTUAL_LIBRARY_TAG:-}
+```
+
+**Détails importants** :
+- `${CALIBRE_HOST_PATH:-/dev/null}` : Permet de désactiver Calibre si la variable n'est pas définie
+- `:ro` : Montage en lecture seule obligatoire pour protéger la bibliothèque
+- Pas de variable `CALIBRE_LIBRARY_PATH` : Le backend détecte automatiquement `/calibre` s'il est monté
+
+## Leçon apprise : Portainer et chemins relatifs
+
+**Problème identifié** : Portainer résout les chemins relatifs différemment de Docker Compose CLI.
+
+- **Docker Compose CLI** : résout `./data/logs` depuis le répertoire du `docker-compose.yml`
+- **Portainer** : résout `./data/logs` depuis son propre répertoire de travail (`/data/compose/X/`)
+
+**Solution** : Toujours utiliser des **chemins absolus** dans les variables d'environnement pour Portainer.
+
+**Documentation ajoutée** dans `.env.example` :
+```bash
+# ⚠️  IMPORTANT pour Portainer : Utiliser des chemins ABSOLUS
+# Portainer résout les chemins relatifs depuis son propre répertoire de travail,
+# pas depuis le répertoire du docker-compose.yml.
+```
+
+Cette leçon a été apprise lors de l'issue #27 sur les logs MongoDB et est maintenant appliquée systématiquement pour toutes les nouvelles variables de chemins.
+
+## Fichiers modifiés
+
+1. **docker-compose.yml** : Ajout volume et variable d'environnement au service backend
+2. **.env.example** : Nouvelle section "Calibre Integration (Optionnel)" avec exemples par plateforme
+3. **docs/user/calibre-setup.md** : Guide complet d'intégration (architecture, configuration, troubleshooting)
+4. **docs/user/.pages** : Ajout de la page Calibre dans la navigation
+
+## Fonctionnalités disponibles
+
+Une fois Calibre configuré, le back-office offre :
+
+### API REST
+- `/api/calibre/status` : Statut de l'intégration
+- `/api/calibre/statistics` : Statistiques de la bibliothèque
+- `/api/calibre/books` : Liste des livres avec recherche, pagination et filtres
+
+### Interface web
+- Recherche en temps réel (titre, auteur, tags)
+- Filtres : tous les livres / lus / non lus
+- Tri par titre, auteur, date d'ajout
+- Mise en surbrillance des termes de recherche
+- Support des colonnes personnalisées Calibre (`#read`, `#paper`, `#text`)
+
+## Considérations de sécurité
+
+### Accès concurrent sécurisé
+
+Calibre et Docker peuvent accéder à la bibliothèque simultanément :
+- **Calibre sur PC/NAS** : Lecture et écriture normales
+- **Docker (backend)** : Lecture seule via SQLite
+
+**Limitation connue** : Si Calibre écrit dans `metadata.db` pendant que Docker lit, une erreur SQLite "database is locked" peut survenir temporairement. Cette erreur est normale et se résout automatiquement.
+
+## Méthodologie de debugging appliquée
+
+Ce projet a suivi le principe "Comprendre AVANT de contourner" documenté dans CLAUDE.md.
+
+Au lieu d'appliquer des solutions de contournement (chmod 777, supprimer les volumes), nous avons :
+1. **Observé** : Collecté les symptômes et logs
+2. **Investigué** : Testé les hypothèses méthodiquement (inspect des mounts, vérification permissions)
+3. **Compris** : Identifié la cause racine (comportement spécifique de Portainer)
+4. **Corrigé** : Appliqué la solution appropriée (chemins absolus)
+5. **Documenté** : Partagé l'apprentissage pour éviter que d'autres rencontrent le même problème
+
+Cette approche a permis de découvrir un comportement important de Portainer qui s'applique à toutes les configurations futures.
+
+## Références
+
+- Issue source : castorfou/back-office-lmelp#119
+- Documentation complète : https://castorfou.github.io/back-office-lmelp/deployment/calibre-setup/
+- Documentation docker-lmelp : https://castorfou.github.io/docker-lmelp/user/calibre-setup/

--- a/docs/user/.pages
+++ b/docs/user/.pages
@@ -3,6 +3,7 @@ nav:
   - A propos de la doc user: README.md
   - Installation: installation.md
   - Configuration: configuration.md
+  - Intégration Calibre: calibre-setup.md
   - Backups & Restauration: backup-restore.md
   - Rotation des logs MongoDB (docker): mongodb-log-rotation.md
   - Rotation des logs MongoDB (ubuntu): mongodb-log-rotation-native.md

--- a/docs/user/calibre-setup.md
+++ b/docs/user/calibre-setup.md
@@ -1,0 +1,269 @@
+# Configuration Calibre
+
+Cette page explique comment intégrer votre bibliothèque Calibre existante au back-office LMELP.
+
+## Vue d'ensemble
+
+L'intégration Calibre permet d'accéder à votre bibliothèque de livres numériques directement depuis l'interface web du back-office. Cette fonctionnalité est **entièrement optionnelle** : le système fonctionne normalement sans Calibre.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    NAS Synology (ou PC)                     │
+│                                                             │
+│  ┌────────────────────────────────────────────────────┐   │
+│  │  Bibliothèque Calibre (sur l'hôte)                 │   │
+│  │  /volume1/books/Calibre Library/                   │   │
+│  │    ├── metadata.db (SQLite)                        │   │
+│  │    └── Author/Book Title (ID)/...                  │   │
+│  └──────────────────┬─────────────────────────────────┘   │
+│                     │ Montage volume Docker (:ro)          │
+│                     ▼                                       │
+│  ┌────────────────────────────────────────────────────┐   │
+│  │  Backend Container (FastAPI)                        │   │
+│  │  /calibre/ (lecture seule)                         │   │
+│  │    └── metadata.db ← Lecture directe via SQLite    │   │
+│  └────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Caractéristiques
+
+- **Lecture seule** : Le volume est monté en `:ro` pour éviter toute modification de votre bibliothèque Calibre
+- **Pas d'installation requise** : Le backend lit directement le fichier `metadata.db` via SQLite, aucune installation de Calibre n'est nécessaire dans le conteneur
+- **Optionnel** : Le système continue de fonctionner normalement si Calibre n'est pas configuré
+- **Accès concurrent sécurisé** : Calibre peut continuer à utiliser la bibliothèque en même temps (lecture seule depuis Docker)
+
+## Configuration
+
+### 1. Prérequis
+
+- Une bibliothèque Calibre existante et fonctionnelle
+- Connaître le chemin absolu de votre bibliothèque Calibre sur l'hôte
+
+### 2. Édition du fichier .env
+
+Ouvrez votre fichier `.env` et ajoutez la section Calibre selon votre plateforme :
+
+#### NAS Synology
+
+```bash
+# Calibre Integration
+CALIBRE_HOST_PATH=/volume1/books/Calibre Library
+```
+
+#### Linux
+
+```bash
+# Calibre Integration
+CALIBRE_HOST_PATH=/home/user/Calibre Library
+```
+
+#### Mac
+
+```bash
+# Calibre Integration
+CALIBRE_HOST_PATH=/Users/username/Calibre Library
+```
+
+#### Windows (WSL2 ou Docker Desktop)
+
+```bash
+# Calibre Integration
+CALIBRE_HOST_PATH=/mnt/c/Users/username/Calibre Library
+```
+
+#### Bibliothèque virtuelle (optionnel)
+
+Si vous utilisez des tags dans Calibre pour organiser vos livres, vous pouvez filtrer l'affichage :
+
+```bash
+# Tag de bibliothèque virtuelle
+CALIBRE_VIRTUAL_LIBRARY_TAG=guillaume
+```
+
+### 3. Important pour Portainer
+
+⚠️ **Si vous déployez via Portainer**, vous **DEVEZ** utiliser des chemins absolus.
+
+Portainer résout les chemins relatifs depuis son propre répertoire de travail (`/data/compose/X/`), pas depuis le répertoire du `docker-compose.yml`. Un chemin relatif comme `./data/calibre` sera transformé en `/data/compose/X/data/calibre` au lieu du chemin attendu.
+
+**Exemple correct pour Portainer** :
+
+```bash
+# ✅ BON (chemin absolu)
+CALIBRE_HOST_PATH=/volume1/books/Calibre Library
+
+# ❌ MAUVAIS (chemin relatif - ne fonctionnera pas dans Portainer)
+CALIBRE_HOST_PATH=./data/calibre
+```
+
+### 4. Redémarrage des services
+
+Après avoir modifié le fichier `.env`, redémarrez la stack :
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+Ou via Portainer : cliquez sur "Update the stack" puis "Pull and redeploy".
+
+## Vérification
+
+### 1. Vérifier le montage du volume
+
+Vérifiez que le volume Calibre est bien monté dans le conteneur backend :
+
+```bash
+docker exec lmelp-backoffice-backend ls -la /calibre
+```
+
+Vous devriez voir le contenu de votre bibliothèque Calibre, notamment le fichier `metadata.db`.
+
+### 2. Vérifier l'API Calibre
+
+Vérifiez que l'API Calibre répond correctement :
+
+```bash
+# Status de Calibre
+curl http://localhost:8000/api/calibre/status
+
+# Statistiques de la bibliothèque
+curl http://localhost:8000/api/calibre/statistics
+
+# Liste des livres (10 premiers)
+curl "http://localhost:8000/api/calibre/books?limit=10"
+```
+
+### 3. Vérifier l'interface web
+
+Accédez à l'interface web du back-office : `http://localhost:8080`
+
+Vous devriez voir un nouvel onglet "Calibre" avec :
+- Barre de recherche temps réel
+- Filtres : tous les livres / lus / non lus
+- Options de tri
+- Liste des livres avec mise en surbrillance des termes de recherche
+
+## Fonctionnalités disponibles
+
+### API REST
+
+Le backend expose trois endpoints principaux :
+
+- **`/api/calibre/status`** : Vérifie si Calibre est configuré et accessible
+- **`/api/calibre/statistics`** : Statistiques de la bibliothèque (nombre de livres, livres lus, etc.)
+- **`/api/calibre/books`** : Liste des livres avec support de la recherche, pagination et filtres
+
+### Interface web
+
+L'interface web offre :
+- **Recherche en temps réel** : Recherche par titre, auteur, tags
+- **Filtres** : Tous les livres / Lus / Non lus
+- **Tri** : Par titre, auteur, date d'ajout
+- **Mise en surbrillance** : Les termes de recherche sont surlignés en jaune
+- **Colonnes personnalisées** : Support de `#read`, `#paper`, `#text`
+
+## Troubleshooting
+
+### Le backend ne démarre pas après avoir activé Calibre
+
+**Symptômes** : Le conteneur backend redémarre en boucle ou affiche des erreurs dans les logs.
+
+**Causes possibles** :
+1. Le chemin `CALIBRE_HOST_PATH` est incorrect ou n'existe pas
+2. Le répertoire n'est pas accessible (permissions)
+3. Le chemin est relatif dans Portainer
+
+**Solutions** :
+1. Vérifiez que le chemin existe sur l'hôte : `ls -la "/volume1/books/Calibre Library"`
+2. Vérifiez les permissions du répertoire
+3. Si vous utilisez Portainer, assurez-vous d'utiliser un **chemin absolu**
+4. Consultez les logs du backend : `docker logs lmelp-backoffice-backend`
+
+### L'API Calibre renvoie "Calibre not configured"
+
+**Symptômes** : `GET /api/calibre/status` renvoie `{"configured": false}`
+
+**Causes possibles** :
+1. La variable `CALIBRE_HOST_PATH` n'est pas définie dans `.env`
+2. Le volume n'est pas monté correctement
+3. Le fichier `metadata.db` n'existe pas dans la bibliothèque
+
+**Solutions** :
+1. Vérifiez que `CALIBRE_HOST_PATH` est bien défini dans `.env`
+2. Vérifiez le montage : `docker exec lmelp-backoffice-backend ls -la /calibre`
+3. Vérifiez que `metadata.db` existe : `docker exec lmelp-backoffice-backend ls -la /calibre/metadata.db`
+
+### Les livres n'apparaissent pas dans l'interface web
+
+**Symptômes** : L'interface Calibre s'affiche mais la liste des livres est vide.
+
+**Causes possibles** :
+1. Le tag de bibliothèque virtuelle est trop restrictif
+2. Tous les livres sont filtrés par un critère de recherche
+3. La bibliothèque Calibre est réellement vide
+
+**Solutions** :
+1. Supprimez ou modifiez `CALIBRE_VIRTUAL_LIBRARY_TAG` dans `.env`
+2. Réinitialisez les filtres de recherche dans l'interface web
+3. Vérifiez les statistiques via `/api/calibre/statistics`
+
+### Erreur "database is locked"
+
+**Symptômes** : Erreur SQLite "database is locked" dans les logs du backend.
+
+**Cause** : Calibre est en train d'écrire dans `metadata.db` en même temps que Docker tente de le lire.
+
+**Solution** :
+- Ce problème est temporaire et se résout automatiquement
+- Le montage en lecture seule (`:ro`) empêche Docker de modifier la base de données
+- Calibre peut continuer à utiliser la bibliothèque normalement
+- Si le problème persiste, fermez Calibre temporairement et redémarrez le backend
+
+## Considérations de sécurité
+
+### Lecture seule
+
+Le volume Calibre est monté en **lecture seule** (`:ro`) dans Docker. Cela signifie que :
+- Le backend ne peut **jamais** modifier votre bibliothèque Calibre
+- Vos données sont protégées contre toute modification accidentelle
+- Vous pouvez continuer à utiliser Calibre normalement sur votre PC/NAS
+
+### Accès concurrent
+
+Calibre et Docker peuvent accéder à la bibliothèque simultanément :
+- **Calibre sur PC/NAS** : Lecture et écriture normales
+- **Docker (backend)** : Lecture seule via SQLite
+
+Limitations :
+- Si Calibre écrit dans `metadata.db` pendant que Docker lit, une erreur "database is locked" peut survenir temporairement
+- Cette erreur est normale et se résout automatiquement après quelques secondes
+- Pour une expérience optimale, évitez d'éditer massivement la bibliothèque Calibre pendant que le backend l'utilise
+
+## Désactivation de Calibre
+
+Pour désactiver l'intégration Calibre :
+
+1. Commentez ou supprimez `CALIBRE_HOST_PATH` dans votre fichier `.env` :
+
+```bash
+# CALIBRE_HOST_PATH=/volume1/books/Calibre Library
+```
+
+2. Redémarrez la stack :
+
+```bash
+docker compose down
+docker compose up -d
+```
+
+L'onglet Calibre disparaîtra de l'interface web et les endpoints API renverront `{"configured": false}`.
+
+## Références
+
+- [Documentation Calibre officielle](https://calibre-ebook.com/)
+- [Format de base de données Calibre](https://manual.calibre-ebook.com/db_api.html)
+- [Dépôt back-office-lmelp](https://github.com/castorfou/back-office-lmelp)

--- a/uv.lock
+++ b/uv.lock
@@ -73,6 +73,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 source = { registry = "https://pypi.org/simple" }
@@ -551,10 +560,14 @@ dev = [
     { name = "click" },
     { name = "cruft" },
     { name = "mkdocs" },
+    { name = "mkdocs-awesome-pages-plugin" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
+    { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pymdown-extensions" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -574,12 +587,16 @@ requires-dist = [
     { name = "ipywidgets" },
     { name = "matplotlib" },
     { name = "mkdocs", marker = "extra == 'dev'", specifier = ">=1.5.0" },
+    { name = "mkdocs-awesome-pages-plugin", marker = "extra == 'dev'" },
     { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'dev'", specifier = ">=1.2.0" },
+    { name = "mkdocs-include-markdown-plugin", marker = "extra == 'dev'" },
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.4.0" },
+    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy" },
     { name = "pandas" },
     { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pymdown-extensions", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "python-dotenv" },
     { name = "ruff", marker = "extra == 'dev'" },
@@ -693,6 +710,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9a/c8/dd58967d119baab745caec2f9d853297cec1989ec1d63f677d3880632b88/gitpython-3.1.45.tar.gz", hash = "sha256:85b0ee964ceddf211c41b9f27a49086010a190fd8132a24e21f362a4b36a791c", size = 215076, upload-time = "2025-07-24T03:45:54.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/61/d4b89fec821f72385526e1b9d9a3a0385dda4a72b206d28049e2c7cd39b8/gitpython-3.1.45-py3-none-any.whl", hash = "sha256:8908cb2e02fb3b93b7eb0f2827125cb699869470432cc885f019b8fd0fccff77", size = 208168, upload-time = "2025-07-24T03:45:52.517Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
 ]
 
 [[package]]
@@ -1162,6 +1191,34 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
+]
+
+[[package]]
+name = "mkdocs-awesome-pages-plugin"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "natsort" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/e8/6ae9c18d8174a5d74ce4ade7a7f4c350955063968bc41ff1e5833cff4a2b/mkdocs_awesome_pages_plugin-2.10.1.tar.gz", hash = "sha256:cda2cb88c937ada81a4785225f20ef77ce532762f4500120b67a1433c1cdbb2f", size = 16303, upload-time = "2024-12-22T21:13:49.19Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/61/19fc1e9c579dbfd4e8a402748f1d63cab7aabe8f8d91eb0235e45b32d040/mkdocs_awesome_pages_plugin-2.10.1-py3-none-any.whl", hash = "sha256:c6939dbea37383fc3cf8c0a4e892144ec3d2f8a585e16fdc966b34e7c97042a7", size = 15118, upload-time = "2024-12-22T21:13:46.945Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1188,6 +1245,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/c5/1d3c4e6ddae6230b89d09105cb79de711655e3ebd6745f7a92efea0f5160/mkdocs_git_revision_date_localized_plugin-1.5.0.tar.gz", hash = "sha256:17345ccfdf69a1905dc96fb1070dce82d03a1eb6b0d48f958081a7589ce3c248", size = 460697, upload-time = "2025-10-31T16:11:34.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/51/fe0e3fdb16f6eed65c9459d12bae6a4e1f0bb4e2228cb037e7907b002678/mkdocs_git_revision_date_localized_plugin-1.5.0-py3-none-any.whl", hash = "sha256:933f9e35a8c135b113f21bb57610d82e9b7bcc71dd34fb06a029053c97e99656", size = 26153, upload-time = "2025-10-31T16:11:32.987Z" },
+]
+
+[[package]]
+name = "mkdocs-include-markdown-plugin"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/10/b0b75ac42f4613556a808eee2dad3efe7a7d5079349aa5b9229d863e829f/mkdocs_include_markdown_plugin-7.2.0.tar.gz", hash = "sha256:4a67a91ade680dc0e15f608e5b6343bec03372ffa112c40a4254c1bfb10f42f3", size = 25509, upload-time = "2025-09-28T21:50:50.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/f9/783338d1d7fd548c7635728b67a0f8f96d9e6c265aa61c51356c03597767/mkdocs_include_markdown_plugin-7.2.0-py3-none-any.whl", hash = "sha256:d56cdaeb2d113fb66ed0fe4fb7af1da889926b0b9872032be24e19bbb09c9f5b", size = 29548, upload-time = "2025-09-28T21:50:49.373Z" },
 ]
 
 [[package]]
@@ -1219,6 +1289,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/13/10bbf9d56565fd91b91e6f5a8cd9b9d8a2b101c4e8ad6eeafa35a706301d/mkdocstrings-1.0.0.tar.gz", hash = "sha256:351a006dbb27aefce241ade110d3cd040c1145b7a3eb5fd5ac23f03ed67f401a", size = 101086, upload-time = "2025-11-27T15:39:40.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/fc/80aa31b79133634721cf7855d37b76ea49773599214896f2ff10be03de2a/mkdocstrings-1.0.0-py3-none-any.whl", hash = "sha256:4c50eb960bff6e05dfc631f6bc00dfabffbcb29c5ff25f676d64daae05ed82fa", size = 35135, upload-time = "2025-11-27T15:39:39.301Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/0d/dab7b08ca7e5a38b033cd83565bb0f95f05e8f3df7bc273e793c2ad3576e/mkdocstrings_python-2.0.0.tar.gz", hash = "sha256:4d872290f595221740a304bebca5b3afa4beafe84cc6fd27314d52dc3fbb4676", size = 199113, upload-time = "2025-11-27T16:44:44.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/de/063481352688c3a1468c51c10b6cfb858d5e35dfef8323d9c83c4f2faa03/mkdocstrings_python-2.0.0-py3-none-any.whl", hash = "sha256:1d552dda109d47e4fddecbb1f06f9a86699c1b073e8b166fba89eeef0a0ffec6", size = 104803, upload-time = "2025-11-27T16:44:43.441Z" },
 ]
 
 [[package]]
@@ -1266,6 +1372,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "natsort"
+version = "8.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/a9/a0c57aee75f77794adaf35322f8b6404cbd0f89ad45c87197a937764b7d0/natsort-8.4.0.tar.gz", hash = "sha256:45312c4a0e5507593da193dedd04abb1469253b601ecaf63445ad80f0a1ea581", size = 76575, upload-time = "2023-06-20T04:17:19.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl", hash = "sha256:4732914fb471f56b5cce04d7bae6f164a592c7712e1c85f9ef585e197299521c", size = 38268, upload-time = "2023-06-20T04:17:17.522Z" },
 ]
 
 [[package]]
@@ -2145,6 +2260,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add support for mounting an existing Calibre library in the backend service, enabling access to books via the back-office web interface.

Changes:
- docker-compose.yml: Add Calibre volume mount (read-only) and env var
- .env.example: Add Calibre configuration section with platform examples
- docs/user/calibre-setup.md: Complete integration guide with troubleshooting
- docs/user/.pages: Add Calibre documentation to navigation
- README.md: Mention Calibre integration in features and documentation
- docs/claude/memory: Document architecture decisions and learnings

Key features:
- Optional integration (system works without Calibre)
- Read-only mount to protect Calibre library
- No Calibre installation required in container (direct SQLite access)
- Multi-platform support (NAS Synology, Linux, Mac, Windows)
- Important note for Portainer users: use absolute paths

API endpoints available once configured:
- /api/calibre/status: Check integration status
- /api/calibre/statistics: Library statistics
- /api/calibre/books: Book list with search and filters

Resolves #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)