### PR TITLE
feat: externaliser le cache Babelio (BABELIO_CACHE_DIR) dans le stack docker-lmelp

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,6 +105,9 @@ LOG_PATH=./data/logs
 # Logs MongoDB (mongod.log, backup.log, rotation.log)
 MONGO_LOG_PATH=./data/logs/mongodb
 
+# Cache Babelio (persisté entre redéploiements Watchtower)
+BABELIO_CACHE_PATH=./data/cache/babelio
+
 # ============================================================================
 # Calibre Integration (Optionnel)
 # ============================================================================
@@ -133,6 +136,15 @@ MONGO_LOG_PATH=./data/logs/mongodb
 # Tag de bibliothèque virtuelle Calibre (optionnel)
 # Permet de filtrer les livres selon un tag spécifique
 # CALIBRE_VIRTUAL_LIBRARY_TAG=guillaume
+
+# ============================================================================
+# Configuration Babelio
+# ============================================================================
+# Délai minimum entre les requêtes vers Babelio (secondes, fair-use)
+BABELIO_FAIR_SEC=2.0
+
+# Durée de validité du cache Babelio (jours)
+BABELIO_CACHE_DAY=30
 
 # ============================================================================
 # Backup Configuration

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
       - mongo
     volumes:
       - ${CALIBRE_HOST_PATH:-/dev/null}:/calibre:ro
+      - ${BABELIO_CACHE_PATH:-./data/cache/babelio}:/cache/babelio
     environment:
       - MONGODB_URL=mongodb://mongo:27017/${MONGO_DATABASE:-masque_et_la_plume}
       - ENVIRONMENT=production
@@ -97,6 +98,10 @@ services:
       - AZURE_DEPLOYMENT_NAME=${AZURE_DEPLOYMENT_NAME:-}
       # Calibre integration (optionnel)
       - CALIBRE_VIRTUAL_LIBRARY_TAG=${CALIBRE_VIRTUAL_LIBRARY_TAG:-}
+      # Cache Babelio (persisté entre redéploiements)
+      - BABELIO_CACHE_DIR=/cache/babelio
+      - BABELIO_FAIR_SEC=${BABELIO_FAIR_SEC:-2.0}
+      - BABELIO_CACHE_DAY=${BABELIO_CACHE_DAY:-30}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s

--- a/docs/claude/memory/260706-2344-babelio-cache-externalise.md
+++ b/docs/claude/memory/260706-2344-babelio-cache-externalise.md
@@ -1,0 +1,56 @@
+# Externalisation du cache Babelio (issue #43)
+
+## Contexte
+
+Le service `backend` (back-office-lmelp) dispose d'un cache disque Babelio avec circuit breaker
+et fair-use. Sans volume externe, ce cache est perdu à chaque redéploiement Watchtower, ce qui
+réintroduit la charge de requêtes et le risque de blocage 403/captcha.
+
+## Ce qui a été fait
+
+### `docker-compose.yml` — service `backend`
+
+Ajout d'un volume externe pour le cache :
+```yaml
+- ${BABELIO_CACHE_PATH:-./data/cache/babelio}:/cache/babelio
+```
+
+Ajout de trois variables d'environnement :
+```yaml
+- BABELIO_CACHE_DIR=/cache/babelio
+- BABELIO_FAIR_SEC=${BABELIO_FAIR_SEC:-2.0}
+- BABELIO_CACHE_DAY=${BABELIO_CACHE_DAY:-30}
+```
+
+`BABELIO_CACHE_DIR` est **fixe** (pas de variable) car c'est le point de montage interne du
+conteneur — seul le chemin hôte (`BABELIO_CACHE_PATH`) est configurable.
+
+### `.env.example`
+
+Deux ajouts :
+- Dans la section "Chemins des Volumes" : `BABELIO_CACHE_PATH=./data/cache/babelio`
+- Nouvelle section "Configuration Babelio" avec `BABELIO_FAIR_SEC=2.0` et `BABELIO_CACHE_DAY=30`
+
+Le défaut de 30 jours a été choisi délibérément (au lieu du défaut 1.0 de back-office-lmelp
+standalone) pour maximiser la persistance du cache en production.
+
+### `data/cache/babelio/.gitkeep`
+
+Répertoire créé avec `.gitkeep` pour que le point de montage existe dès le clone du repo
+(cohérence avec `data/backups/`, `data/logs/`, `data/logs/mongodb/`).
+
+### `tests/test_docker_compose.py`
+
+Nouvelle classe `TestBabelioCacheConfiguration` (6 tests) validant :
+- Présence des 3 variables d'environnement Babelio dans `backend`
+- Valeur fixe de `BABELIO_CACHE_DIR=/cache/babelio`
+- Présence d'un volume monté sur `/cache/babelio`
+- Utilisation de la variable `BABELIO_CACHE_PATH` pour le chemin hôte
+
+## Décisions techniques
+
+- `BABELIO_CACHE_DAY=30` (pas 1.0) : en prod avec Watchtower, un cache de 30 jours réduit
+  drastiquement les requêtes répétées vers Babelio entre deux redéploiements.
+- Le chemin interne `/cache/babelio` est cohérent avec le déploiement standalone de
+  `back-office-lmelp` (`docker/deployment/docker-compose.yml`).
+- Approche TDD : tests RED écrits en premier, puis modifications `docker-compose.yml`.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -163,6 +163,20 @@ MONGODB_URL=mongodb://localhost:27017/masque_et_la_plume
 
 La variable `MONGODB_URL` doit correspondre à la configuration MongoDB (même hôte que `DB_HOST`).
 
+### Cache Babelio
+
+Le backend utilise un cache disque pour les requêtes Babelio, avec un mécanisme de fair-use et un circuit breaker.
+
+```bash
+# Délai minimum entre les requêtes Babelio (secondes)
+BABELIO_FAIR_SEC=2.0
+
+# Durée de validité du cache Babelio (jours)
+BABELIO_CACHE_DAY=30
+```
+
+Le chemin du cache sur l'hôte est configuré via `BABELIO_CACHE_PATH` (voir section [Chemins des volumes](#chemins-des-volumes)).
+
 ### Frontend
 
 ```bash
@@ -192,6 +206,9 @@ LOG_PATH=./data/logs
 
 # Logs MongoDB (mongod.log, backup.log, logrotate.log)
 MONGO_LOG_PATH=./data/logs/mongodb
+
+# Cache Babelio (persisté entre redéploiements)
+BABELIO_CACHE_PATH=./data/cache/babelio
 ```
 
 **Note sur les logs** :
@@ -213,12 +230,13 @@ BACKUP_PATH=/mnt/storage/lmelp/backups
 AUDIO_PATH=/mnt/storage/lmelp/audios
 LOG_PATH=/mnt/storage/lmelp/logs
 MONGO_LOG_PATH=/mnt/storage/lmelp/logs/mongodb
+BABELIO_CACHE_PATH=/mnt/storage/lmelp/cache/babelio
 ```
 
 **Important** : Créer les répertoires avant de démarrer la stack :
 
 ```bash
-mkdir -p /mnt/storage/lmelp/{mongodb,backups,audios,logs/mongodb}
+mkdir -p /mnt/storage/lmelp/{mongodb,backups,audios,logs/mongodb,cache/babelio}
 chmod -R 755 /mnt/storage/lmelp
 
 # MongoDB a besoin que le répertoire de logs ait les bonnes permissions

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -97,3 +97,75 @@ class TestDockerComposeConfiguration:
         assert "/health" in command_str, (
             "frontend healthcheck should use /health endpoint"
         )
+
+
+class TestBabelioCacheConfiguration:
+    """Tests for Babelio cache externalization in backend service."""
+
+    def _get_backend(self):
+        with open("docker-compose.yml") as f:
+            config = yaml.safe_load(f)
+        return config["services"]["backend"]
+
+    def _get_env_list(self, backend):
+        """Return backend environment as a list of strings."""
+        env = backend.get("environment", [])
+        if isinstance(env, dict):
+            return [f"{k}={v}" for k, v in env.items()]
+        return env
+
+    def test_backend_has_babelio_cache_dir_env(self):
+        """Verify that backend defines BABELIO_CACHE_DIR environment variable."""
+        backend = self._get_backend()
+        env_list = self._get_env_list(backend)
+        env_keys = [e.split("=")[0] for e in env_list]
+        assert "BABELIO_CACHE_DIR" in env_keys, (
+            "backend should define BABELIO_CACHE_DIR environment variable"
+        )
+
+    def test_backend_has_babelio_fair_sec_env(self):
+        """Verify that backend defines BABELIO_FAIR_SEC environment variable."""
+        backend = self._get_backend()
+        env_list = self._get_env_list(backend)
+        env_keys = [e.split("=")[0] for e in env_list]
+        assert "BABELIO_FAIR_SEC" in env_keys, (
+            "backend should define BABELIO_FAIR_SEC environment variable"
+        )
+
+    def test_backend_has_babelio_cache_day_env(self):
+        """Verify that backend defines BABELIO_CACHE_DAY environment variable."""
+        backend = self._get_backend()
+        env_list = self._get_env_list(backend)
+        env_keys = [e.split("=")[0] for e in env_list]
+        assert "BABELIO_CACHE_DAY" in env_keys, (
+            "backend should define BABELIO_CACHE_DAY environment variable"
+        )
+
+    def test_babelio_cache_dir_fixed_value(self):
+        """Verify that BABELIO_CACHE_DIR is set to /cache/babelio (fixed path)."""
+        backend = self._get_backend()
+        env_list = self._get_env_list(backend)
+        cache_dir_entry = next(
+            (e for e in env_list if e.startswith("BABELIO_CACHE_DIR=")), None
+        )
+        assert cache_dir_entry is not None, "BABELIO_CACHE_DIR should be defined"
+        assert cache_dir_entry == "BABELIO_CACHE_DIR=/cache/babelio", (
+            "BABELIO_CACHE_DIR should be set to /cache/babelio"
+        )
+
+    def test_backend_has_babelio_cache_volume(self):
+        """Verify that backend mounts an external volume for Babelio cache."""
+        backend = self._get_backend()
+        volumes = backend.get("volumes", [])
+        has_babelio_volume = any("/cache/babelio" in str(v) for v in volumes)
+        assert has_babelio_volume, "backend should mount a volume for /cache/babelio"
+
+    def test_babelio_cache_volume_uses_env_variable(self):
+        """Verify that Babelio cache volume path is configurable via BABELIO_CACHE_PATH."""
+        backend = self._get_backend()
+        volumes = backend.get("volumes", [])
+        babelio_volume = next((v for v in volumes if "/cache/babelio" in str(v)), None)
+        assert babelio_volume is not None, "Babelio cache volume should exist"
+        assert "BABELIO_CACHE_PATH" in str(babelio_volume), (
+            "Babelio cache volume should use BABELIO_CACHE_PATH variable"
+        )


### PR DESCRIPTION
Closes #43

## Summary

- Ajoute un volume externe `${BABELIO_CACHE_PATH:-./data/cache/babelio}:/cache/babelio` sur le service `backend` pour persister le cache Babelio entre les redéploiements Watchtower
- Configure les variables d'environnement `BABELIO_CACHE_DIR=/cache/babelio`, `BABELIO_FAIR_SEC` (défaut 2.0s) et `BABELIO_CACHE_DAY` (défaut 30 jours)
- Documente les nouvelles variables dans `.env.example` et `docs/user/configuration.md`
- Crée `data/cache/babelio/.gitkeep` pour que le point de montage existe dès le clone

## Test plan

- [x] 6 tests TDD ajoutés dans `TestBabelioCacheConfiguration` (tests/test_docker_compose.py)
- [x] CI verte (Python 3.11, 3.12, pre-commit, build)
- [x] `mkdocs build --strict` sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)