### PR TITLE
docs: expliquer le piège Watchtower/Portainer pour le cache Babelio (#45)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ data/logs/*
 !data/backups/.gitkeep
 !data/audios/.gitkeep
 !data/logs/.gitkeep
+data/cache/*
 
 # ML models
 *.model

--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,7 @@ data/logs/*
 !data/audios/.gitkeep
 !data/logs/.gitkeep
 data/cache/*
+!data/cache/babelio/.gitkeep
 
 # ML models
 *.model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,16 @@ Cette différence de comportement a été identifiée lors du diagnostic d'un pr
 
 Cette approche prend parfois plus de temps initialement, mais économise énormément de temps à long terme et améliore la maîtrise du système.
 
+### Watchtower ne réapplique pas les changements de `docker-compose.yml`
+
+**Deuxième piège du même type** (identifié lors du diagnostic de l'issue #45 : cache Babelio qui
+reste vide malgré un volume ajouté) : Watchtower ne fait que surveiller les nouvelles images et
+recrée le conteneur avec **la configuration Docker déjà en place** (mêmes volumes, mêmes
+variables d'environnement) — il ne relit jamais `docker-compose.yml`. Après avoir ajouté un
+volume ou une variable d'environnement dans le compose file, un redéploiement explicite de la
+stack est nécessaire (Portainer : "Update the stack" ; CLI : `docker compose up -d
+--force-recreate`), sans quoi le conteneur continue de tourner avec l'ancienne configuration.
+
 ### Installation
 1. Ouvrir le projet dans VS Code
 2. Accepter la proposition d'ouvrir dans un Dev Container

--- a/docs/claude/memory/260707-0100-issue45-babelio-cache-vide-watchtower.md
+++ b/docs/claude/memory/260707-0100-issue45-babelio-cache-vide-watchtower.md
@@ -1,0 +1,126 @@
+# Diagnostic issue #45 — Le cache Babelio ne se remplit pas
+
+**Date**: 2026-07-07 01:00
+**Issue**: #45 - le cache babelio ne se remplit pas
+**Branch**: `45-le-cache-babelio-ne-se-remplit-pas`
+
+## Problème initial
+
+Après le merge de la PR #44 (issue #43, externalisation du volume + variables d'env
+`BABELIO_CACHE_DIR`/`BABELIO_FAIR_SEC`/`BABELIO_CACHE_DAY` pour le service `backend`), le
+répertoire hôte `data/cache/babelio/` restait vide, alors que la page de contrôle Babelio du
+back-office affichait bien des entrées de cache.
+
+## Diagnostic
+
+`docker-compose.yml` était **correct** dès le départ (volume
+`${BABELIO_CACHE_PATH:-./data/cache/babelio}:/cache/babelio` + env `BABELIO_CACHE_DIR=/cache/babelio`
+sur `backend`) — pas de bug de configuration dans ce repo.
+
+Investigation du code applicatif de `back-office-lmelp` (repo séparé, lu via GitHub car le code
+n'est pas vendored ici) :
+- `back_office_lmelp/settings.py::babelio_cache_dir` lit `BABELIO_CACHE_DIR`, avec un défaut
+  interne `<cwd>/data/processed/babelio_cache` si la variable est absente.
+- `back_office_lmelp/app.py` (lifespan) attache `babelio_service.cache_service =
+  BabelioCacheService(cache_dir=settings.babelio_cache_dir, ...)` au démarrage ; les endpoints
+  `/api/babelio/status` et `/api/babelio/cache/entries` lisent ce même `cache_service`.
+
+**Preuve terrain** (inspection directe du conteneur `backend` par l'utilisateur) : `/cache`
+n'existait pas du tout dans le conteneur, et les `.json` du cache étaient bien présents sous
+`/app/data/processed/babelio_cache` — le chemin de repli interne. Le conteneur `backend` en cours
+d'exécution ne connaissait donc pas encore `BABELIO_CACHE_DIR`.
+
+**Root cause confirmée** : depuis le merge de la PR #44, seul **Watchtower** avait tourné (mise à
+jour de l'image `backend`), sans redéploiement manuel de la stack. Watchtower ne fait que
+surveiller les nouvelles images et recrée le conteneur avec **la configuration Docker déjà en
+place** (mêmes volumes, mêmes variables d'env) — il ne relit jamais `docker-compose.yml`. Un
+changement structurel du compose file (nouveau volume, nouvelles variables d'env) nécessite donc
+un redéploiement complet de la stack, pas juste une mise à jour d'image.
+
+## Complication rencontrée lors de la correction en prod
+
+La stack Portainer (`lmelp-stack`) était en statut **"Limited" / "created outside of Portainer"**,
+rendant le bouton "Update the stack" peu fiable. Contournement CLI testé et validé :
+
+```bash
+# 1. Retrouver le nom du projet Compose utilisé par Portainer pour cette stack
+docker inspect lmelp-mongo --format '{{index .Config.Labels "com.docker.compose.project"}}'
+# → lmelp-stack
+
+# 2. Recréer uniquement le backend avec ce nom de projet
+docker compose -p lmelp-stack up -d --force-recreate backend
+```
+
+⚠️ Sans `-p lmelp-stack`, `docker compose up -d` dérive le nom de projet du nom du dossier
+courant (`docker-lmelp`), différent du nom utilisé par Portainer — ce qui crée un nouveau réseau
+et provoque un conflit sur les noms de conteneurs fixes (`container_name: lmelp-mongo`, etc.)
+déjà utilisés par le projet `lmelp-stack`.
+
+## Modifications apportées
+
+Pas de changement à `docker-compose.yml` ni `.env.example` (déjà corrects, déjà couverts par
+`TestBabelioCacheConfiguration` dans `tests/test_docker_compose.py`). Le fix est purement
+documentaire :
+
+- `docs/user/configuration.md` : nouvel encart d'avertissement dans la section "Cache Babelio"
+  (limite de Watchtower, commandes de vérification `docker exec`/`docker inspect`, contournement
+  CLI pour le cas Portainer "Limited" avec le nom de projet Compose).
+- `CLAUDE.md` : nouveau paragraphe "Watchtower ne réapplique pas les changements de
+  `docker-compose.yml`", à la suite de la section "Méthodologie de debugging" existante (qui
+  documentait déjà un piège similaire pour la résolution des chemins Portainer).
+- `.gitignore` : ajout de `data/cache/*` (commit de l'utilisateur, hors session Claude, suite à
+  son test local qui a rempli `data/cache/babelio/` de vrais fichiers de cache) — complété par
+  `!data/cache/babelio/.gitkeep` pour rester cohérent avec le pattern déjà utilisé pour
+  `data/mongodb/`, `data/backups/`, `data/audios/` et `data/logs/` (garder la structure, ignorer
+  le contenu).
+
+## Apprentissages
+
+### Deuxième variante du piège "Portainer résout la config différemment"
+
+Le projet documentait déjà dans `CLAUDE.md` le piège des chemins relatifs résolus différemment
+par Portainer (issue MongoDB logs). Cette issue révèle une **deuxième variante** du même type de
+piège opérationnel, orthogonale à la première : ce n'est pas la résolution de chemin qui pose
+problème ici, mais le fait que **Watchtower et Portainer ne partagent pas la même vision de la
+configuration** — Watchtower recrée un conteneur à l'identique (sauf l'image), Portainer peut
+perdre le tracking d'une stack (cf. `251126-0009-portainer-stack-detachment-fix.md` pour un
+précédent lié, mais avec un mécanisme différent : directive `build:` causant un détachement du
+conteneur `mongo` seul). Dans ce cas-ci, c'est la stack entière qui est passée en "Limited".
+
+### Investigation cross-repo
+
+Ce repo (`docker-lmelp`) ne contient que l'orchestration Docker ; le code applicatif du cache
+Babelio vit dans `back-office-lmelp` (repo séparé). Pour diagnostiquer une issue dont le symptôme
+touche un volume de ce repo mais dont la cause peut être applicative, il a été nécessaire de lire
+le code source de `back-office-lmelp` via `gh search code` / `curl` sur `raw.githubusercontent.com`
+(pas de submodule, pas de vendoring local) — `back_office_lmelp/settings.py`,
+`back_office_lmelp/app.py`, `back_office_lmelp/services/babelio_cache_service.py`.
+
+### Valeur de la preuve terrain avant de conclure
+
+L'hypothèse initiale (Watchtower + pas de redéploiement) reposait sur la lecture de code et un
+raisonnement par déduction. Elle n'a été confirmée qu'après que l'utilisateur a directement
+inspecté le conteneur en prod (`docker exec` puis `ls /` et `ls /app/data/processed/`). Cette
+preuve terrain a évité de partir sur un fix incorrect (ex. modifier `docker-compose.yml` alors
+qu'il n'y avait rien à corriger côté configuration).
+
+### Pas de test pytest pour un simple avertissement de prose
+
+J'avais initialement ajouté un `tests/test_documentation.py` avec 3 assertions `in content` sur
+`docs/user/configuration.md`, en RED/GREEN. L'utilisateur l'a supprimé : "ça n'ajoute rien ce
+test". Un test qui vérifie juste la présence de mots-clés dans de la documentation prose n'a pas
+de valeur réelle (il ne prévient d'aucune régression fonctionnelle, il est fragile si le texte est
+reformulé). Ne pas reproduire ce réflexe de "TDD partout" pour des changements purement
+documentaires — le TDD RED/GREEN de ce workflow s'applique au code, pas à la prose.
+
+## Références
+
+- Issue : #45
+- Commentaire de diagnostic posté sur l'issue :
+  https://github.com/castorfou/docker-lmelp/issues/45#issuecomment-4898292602
+- Fichiers modifiés :
+  - `docs/user/configuration.md` (avertissement Cache Babelio)
+  - `CLAUDE.md` (paragraphe Watchtower)
+  - `.gitignore` (négation `.gitkeep` pour `data/cache/babelio/`)
+- Mémoire liée : `260706-2344-babelio-cache-externalise.md` (PR #44),
+  `251126-0009-portainer-stack-detachment-fix.md` (précédent lié aux pertes de tracking Portainer)

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -177,6 +177,41 @@ BABELIO_CACHE_DAY=30
 
 Le chemin du cache sur l'hôte est configuré via `BABELIO_CACHE_PATH` (voir section [Chemins des volumes](#chemins-des-volumes)).
 
+!!! warning "Le répertoire de cache reste vide après ajout du volume ?"
+    Si `data/cache/babelio` (ou le chemin défini par `BABELIO_CACHE_PATH`) reste vide alors
+    que la page de contrôle Babelio du back-office affiche des entrées, c'est presque toujours
+    parce que le conteneur `backend` **n'a pas été recréé** depuis l'ajout de ce volume et de ces
+    variables d'environnement dans `docker-compose.yml`.
+
+    **Watchtower ne suffit pas** : il se contente de mettre à jour l'image du conteneur avec la
+    configuration Docker déjà en place (mêmes volumes, mêmes variables d'env) — il ne relit jamais
+    `docker-compose.yml`. Tant que le conteneur n'a pas été explicitement recréé,
+    `BABELIO_CACHE_DIR` n'existe pas dans son environnement, et l'application retombe sur un
+    chemin de cache interne
+    (`data/processed/babelio_cache`), non persisté et invisible côté hôte.
+
+    **Vérifier** :
+    ```bash
+    docker exec lmelp-backoffice-backend env | grep BABELIO_CACHE_DIR
+    docker inspect lmelp-backoffice-backend --format '{{json .Mounts}}'
+    ```
+    Si `BABELIO_CACHE_DIR` est absent ou que le mount `/cache/babelio` n'apparaît pas, il faut
+    recréer le conteneur `backend` :
+
+    - **Portainer** : "Update the stack" (en cochant le re-pull de l'image).
+    - **Si la stack apparaît en statut "Limited" ("created outside of Portainer")** : le bouton
+      "Update the stack" ne réapplique pas la config. Passer par la CLI, directement sur
+      l'hôte/NAS, depuis le dossier du repo :
+      ```bash
+      # 1. Retrouver le nom du projet Compose utilisé par Portainer pour cette stack
+      docker inspect lmelp-mongo --format '{{index .Config.Labels "com.docker.compose.project"}}'
+
+      # 2. Recréer uniquement le backend avec ce nom de projet (⚠️ sans -p, Compose utilise
+      #    par défaut le nom du dossier courant, différent du nom de projet Portainer — ce qui
+      #    provoque un conflit sur les noms de conteneurs fixes de mongo/lmelp/frontend)
+      docker compose -p <nom-du-projet> up -d --force-recreate backend
+      ```
+
 ### Frontend
 
 ```bash


### PR DESCRIPTION
## Résumé

Résout #45 — le cache Babelio ne se remplissait pas côté hôte malgré des entrées visibles dans la page de contrôle du back-office.

**Root cause** (confirmée en conditions réelles) : `docker-compose.yml` était déjà correct. Le conteneur `backend` n'avait simplement jamais été redéployé depuis l'ajout du volume/env Babelio (PR #44) — seul Watchtower avait mis à jour l'image, sans recréer le conteneur avec la nouvelle configuration. Watchtower ne relit jamais `docker-compose.yml` : il recrée le conteneur avec les volumes/env déjà en place. Sans redéploiement explicite, `BABELIO_CACHE_DIR` restait absent, et l'app retombait sur un chemin de cache interne non persisté (`/app/data/processed/babelio_cache`).

Complication rencontrée : la stack Portainer étant en statut "Limited" ("created outside of Portainer"), le bouton "Update the stack" ne suffisait pas. Solution testée et validée : `docker compose -p <nom-du-projet> up -d --force-recreate backend` (en retrouvant le nom de projet via `docker inspect ... com.docker.compose.project`).

- `docs/user/configuration.md` : nouvel avertissement dans la section "Cache Babelio" (limite Watchtower, commandes de vérification, contournement CLI pour le cas Portainer "Limited")
- `CLAUDE.md` : capitalisation de cette 2e variante du piège Portainer (après celui des chemins de volumes)
- `.gitignore` : ajout de l'exception `.gitkeep` manquante pour `data/cache/babelio/`, cohérente avec les autres répertoires `data/*`
- Mémoire de session : `docs/claude/memory/260707-0100-issue45-babelio-cache-vide-watchtower.md`

Aucun changement de code/config n'était nécessaire (`docker-compose.yml` déjà correct et couvert par les tests existants `TestBabelioCacheConfiguration`).

## Test plan

- [x] `pytest` (16 passés ; les échecs `test_mongodb_image.py` sont préexistants, liés à l'absence de daemon Docker dans ce devcontainer)
- [x] `ruff check .` / `ruff format --check .`
- [x] `pre-commit run --all-files`
- [x] `mkdocs build --strict`
- [x] CI GitHub Actions verte sur la branche
- [x] Validé en conditions réelles par l'utilisateur : redéploiement du `backend` avec `docker compose -p lmelp-stack up -d --force-recreate backend` → cache Babelio bien rempli côté hôte

🤖 Generated with [Claude Code](https://claude.com/claude-code)